### PR TITLE
Change key-id and rnext-key-id to leafrefs

### DIFF
--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -105,7 +105,9 @@ module ietf-tcp {
     }
 
     leaf current-key {
-      type binary;
+      type leafref {
+	path "../mkt";
+      }
       description
         "The Master Key Tuple (MKT) currently used to authenticate
          outgoing segments, whose SendID is inserted in outgoing
@@ -122,7 +124,9 @@ module ietf-tcp {
     }
 
     leaf rnext-key {
-      type binary;
+      type leafref {
+	path "../mkt";
+      }
       description
 	"The MKT currently preferred for incoming (received)
          segments, whose RecvID is inserted in outgoing segments as


### PR DESCRIPTION
In reviewing the TCP-AO configuration, I ran into what I think is an oddity. I am therefore proposing a change, which I will be the first to admit I am not entirely sure of. One of you will surely correct me if I am wrong.

The current AO grouping has three attributes:
- key-id (type binary)
- rnext-key-id (type binary)
- leaf-list mkt (type binary)

My understanding of this is that the leaf-list of mkt is nothing but a list of mkt that are either currently key-id or rnext-key-id. So shouldn't key-id and rnext-key-id be a leafref to mkt. Of course, when a particular mkt is no longer in use (because of rollover), they need to be deleted. But that should not happen before the key-id or rnext-key-id leafref is updated.

Or am I not getting this??

Finally, I am not sure why we have a separate grouping called mkt. How is that going to be used in this or any other model?