### PR TITLE
MD5 support

### DIFF
--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -174,6 +174,16 @@ module ietf-tcp {
       description
         "Enable support of MD5 to authenticate a TCP session.";
     }
+
+    leaf key {
+      type binary;
+      must "../enable-md5 = 'true'";
+      mandatory true;
+      description
+        "The key to be used to generate the MD5 digest either to
+         insert in an outgoing segment or for validating a received
+         segment.";
+    }
   }
 
   // TCP general configuration groupings
@@ -288,11 +298,26 @@ module ietf-tcp {
 
 	container common {
 	  uses tcpcmn:tcp-common-grouping;
-	  uses ao;
-	  description
-	    "Common definitions of TCP configuration. This includes
-             parameters such as keepalives and idle time, that can
-             be part of either the client or server.";
+          choice secure {
+            case ao {
+              uses ao;
+              description
+                "Use TCP-AO to secure the connection.";
+            }
+
+            case md5 {
+              uses md5;
+              description
+                "Use TCP-MD5 to secure the connection.";
+            }
+            description
+              "Choice of how to secure the TCP connection.";
+          }
+          description
+            "Common definitions of TCP configuration. This includes
+             parameters such as how to secure the connection,
+             keepalives and idle time, that can be part of either
+             the client or server.";
 	}
 
 	container server {

--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -298,7 +298,7 @@ module ietf-tcp {
 
 	container common {
 	  uses tcpcmn:tcp-common-grouping;
-          choice secure {
+          choice authentication {
             case ao {
               uses ao;
               description


### PR DESCRIPTION
Add the key used to compute the MD5 hash. Also make it part of a choice to secure a TCP connection.

Added the choice statement because a connection can be secured using AO or MD5, but not both. I am not entirely sure of who indicates the choice. For example, should the mere presence of one or the other indicate which one is going to be used. Also, if both are present, which one is picked by default.