### PR TITLE
Reducing the model to the bare minimum

### DIFF
--- a/draft/draft-scharf-tcpm-yang-tcp.xml
+++ b/draft/draft-scharf-tcpm-yang-tcp.xml
@@ -37,39 +37,18 @@
     </author>
 
     <author fullname="Vishal Murgai" initials="V." surname="Murgai">
-      <organization abbrev="Cisco Systems Inc">Cisco Systems
-      Inc</organization>
+      <organization/>
 
       <address>
-        <!--<postal>
-        <street></street>
-        <code></code>
-        <city></city>
-        <region></region>
-        <country></country>
-      </postal>-->
-
-        <!--<phone></phone>-->
-
-        <email>vmurgai@cisco.com</email>
+        <email>vmurgai@gmail.com</email>
       </address>
     </author>
 
     <author fullname="Mahesh Jethanandani" initials="M."
             surname="Jethanandani">
-      <organization abbrev="VMware">VMware</organization>
+      <organization>Kloud Services</organization>
 
       <address>
-        <!--<postal>
-        <street></street>
-        <code></code>
-        <city></city>
-        <region></region>
-        <country></country>
-      </postal>-->
-
-        <!--<phone></phone>-->
-
         <email>mjethanandani@gmail.com</email>
       </address>
     </author>

--- a/draft/draft-scharf-tcpm-yang-tcp.xml
+++ b/draft/draft-scharf-tcpm-yang-tcp.xml
@@ -40,7 +40,7 @@
       <organization/>
 
       <address>
-        <email>vmurgai@gmail.com</email>
+        <email>vmurgai at gmail dot com</email>
       </address>
     </author>
 
@@ -53,7 +53,7 @@
       </address>
     </author>
 
-    <date day="1" month="June" year="2020"/>
+    <date day="10" month="June" year="2020"/>
 
     <area>Transport</area>
 
@@ -120,10 +120,10 @@
       <section title="Note to  RFC Editor">
         <t>This document uses several placeholder values throughout the
         document. Please replace them as follows and remove this note before
-        publication. </t>
+        publication.</t>
 
         <t>RFC XXXX, where XXXX is the number assigned to this document at the
-        time of publication. </t>
+        time of publication.</t>
 
         <t>YYYY-MM-DD with the actual date of the publication of this
         document.</t>

--- a/draft/draft-scharf-tcpm-yang-tcp.xml
+++ b/draft/draft-scharf-tcpm-yang-tcp.xml
@@ -74,7 +74,7 @@
       </address>
     </author>
 
-    <date day="24" month="May" year="2020"/>
+    <date day="1" month="June" year="2020"/>
 
     <area>Transport</area>
 
@@ -137,6 +137,18 @@
       "OPTIONAL" in this document are to be interpreted as described in BCP 14
       <xref target="RFC2119"/> <xref target="RFC8174"/> when, and only when,
       they appear in all capitals, as shown here.</t>
+
+      <section title="Note to  RFC Editor">
+        <t>This document uses several placeholder values throughout the
+        document. Please replace them as follows and remove this note before
+        publication. </t>
+
+        <t>RFC XXXX, where XXXX is the number assigned to this document at the
+        time of publication. </t>
+
+        <t>YYYY-MM-DD with the actual date of the publication of this
+        document.</t>
+      </section>
     </section>
 
     <section title="Model Overview">
@@ -283,10 +295,7 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD-abridged-tree.txt)
       </section>
     </section>
 
-    <section title="TCP Configuration YANG Model">
-      <t>Editor's note: How to use ietf-tcp-common as basis? For instance, is
-      the tcp-system-grouping therein needed?</t>
-
+    <section title="TCP YANG Model">
       <t><figure>
           <artwork><![CDATA[
 <CODE BEGINS> file "ietf-tcp@YYYY-MM-DD.yang"
@@ -400,25 +409,25 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD.yang)
     </references>
 
     <references title="Informative References">
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.4022.xml"?>
+      <?rfc include='reference.RFC.4022'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.4898.xml"?>
+      <?rfc include='reference.RFC.4898'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.5925.xml"?>
+      <?rfc include='reference.RFC.5925'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.6643.xml"?>
+      <?rfc include='reference.RFC.6643'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.8512.xml"?>
+      <?rfc include='reference.RFC.8512'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.8513.xml"?>
+      <?rfc include='reference.RFC.8513'?>
 
-      <?rfc include="http://xml.resource.org/public/rfc/bibxml/reference.RFC.8519.xml"?>
+      <?rfc include='reference.RFC.8519'?>
 
-      <?rfc include="reference.I-D.ietf-dots-data-channel.xml"?>
+      <?rfc include='reference.I-D.ietf-dots-data-channel'?>
 
-      <?rfc include="reference.I-D.ietf-idr-bgp-model.xml"?>
+      <?rfc include='reference.I-D.ietf-idr-bgp-model'?>
 
-      <?rfc include="reference.I-D.ietf-taps-interface.xml"?>
+      <?rfc include='reference.I-D.ietf-taps-interface'?>
     </references>
 
     <section anchor="app_ack" title="Acknowledgements">
@@ -473,17 +482,6 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD.yang)
 INSERT_TEXT_FROM_FILE(../src/yang/example-tcp-configuration-a.1.1.xml)
 ]]></artwork>
           </figure></t>
-      </section>
-
-      <section title="Global Configuration">
-        <t>This particular example demonstrates how the server can be
-        configured globally for its parameters.</t>
-
-        <figure>
-          <artwork><![CDATA[
-INSERT_TEXT_FROM_FILE(../src/yang/example-tcp-configuration-a.1.2.xml)
-]]></artwork>
-        </figure>
       </section>
     </section>
   </back>

--- a/draft/draft-scharf-tcpm-yang-tcp.xml
+++ b/draft/draft-scharf-tcpm-yang-tcp.xml
@@ -53,7 +53,7 @@
       </address>
     </author>
 
-    <date day="10" month="June" year="2020"/>
+    <date day="20" month="June" year="2020"/>
 
     <area>Transport</area>
 
@@ -419,6 +419,20 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD.yang)
 
     <section anchor="app_changes"
              title="Changes compared to previous versions">
+      <t>Changes compared to draft-scharf-tcpm-yang-tcp-04</t>
+
+      <t><list style="symbols">
+          <t>Removed congestion control</t>
+
+          <t>Removed global stack parameters</t>
+        </list>Changes compared to draft-scharf-tcpm-yang-tcp-03</t>
+
+      <t><list style="symbols">
+          <t>Updated TCP-AO grouping</t>
+
+          <t>Added congestion control</t>
+        </list></t>
+
       <t>Changes compared to draft-scharf-tcpm-yang-tcp-02</t>
 
       <t><list style="symbols">

--- a/src/yang/example-tcp-configuration-a.1.1.xml
+++ b/src/yang/example-tcp-configuration-a.1.1.xml
@@ -23,7 +23,7 @@
       </connection>
     </connections>
     <!--
-     It is not clear why a server and client configuraiton is
+     It is not clear why a server and client configuration is
      needed here even as they under a feature statement and therefore
      are required only if the feature is declared. Adding it so
      that yanglint allows this validation to run.

--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -29,7 +29,7 @@ module ietf-tcp {
      WG List:  <tcpm@ietf.org>
 
      Authors: Michael Scharf (michael.scharf at hs-esslingen dot de)
-              Vishal Murgai (vmurgai at cisco dot com)
+              Vishal Murgai (vmurgai at gmail dot com)
               Mahesh Jethanandani (mjethanandani at gmail dot com)";
 
   description

--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -62,50 +62,6 @@ module ietf-tcp {
 
   // TCP-AO Groupings
 
-  grouping mkt {
-    leaf options {
-      type binary;
-      description
-	"This flag indicates whether TCP options other than TCP-AO
-         are included in the MAC calculation. When options are
-         included, the content of all options, in the order present,
-         is included in the MAC, with TCP-AO's MAC field zeroed out.
-         When the options are not included, all options other than
-         TCP-AO are excluded from all MAC calculations (skipped over,
-         not zeroed).
-
-         Note that TCP-AO, with its MAC field zeroed out, is always
-         included in the MAC calculation, regardless of the setting
-         of this flag; this protects the indication of the MAC length
-         as well as the key ID fields (KeyID, RNextKeyID). The option
-         flag applies to TCP options in both directions
-         (incoming and outgoing segments).";
-      reference
-        "RFC 5925: The TCP Authentication Option.";
-    }
-
-    leaf key-id {
-      type uint8;
-      description
-	"An unsigned 1-byte field indicating the Master Key Tuple
-         (MKT) used to generate the traffic keys that were used to
-         generate the MAC that authenticates this segment.";
-      reference
-	"RFC 5925: The TCP Authentication Option.";
-    }
-
-    leaf rnext-key-id {
-      type uint8;
-      description
-	"An unsigned 1-byte field indicating the MKT that is
-         ready at the sender to be used to authenticate received
-         segments, i.e., the desired 'receive next' key ID.";
-    }
-    description
-      "A Master Key Tuple (MKT) describes TCP-AO properties to be
-       associated with one or more connections.";
-  }
-
   grouping ao {
     leaf enable-ao {
       type boolean;
@@ -157,6 +113,8 @@ module ietf-tcp {
       "RFC 5925: The TCP Authentication Option.";
   }
 
+  // MD5 grouping
+
   grouping md5 {
     description
       "Grouping for use in authenticating TCP sessions using MD5.";
@@ -169,152 +127,6 @@ module ietf-tcp {
       default "false";
       description
         "Enable support of MD5 to authenticate a TCP session.";
-    }
-  }
-
-  // Congestion control
-
-  identity congestion-control-algorithm {
-    description
-      "Base identity from which all congestion control 
-       algorithms are derived.";
-  }
-
-  identity reno {
-    base congestion-control-algorithm;
-    description
-      "Standard TCP congestion control referred to as
-       'Reno algorithm'";
-    reference
-      "RFC 5681: TCP Congestion Control";
-  }
-
-  identity new-reno {
-    base congestion-control-algorithm;
-    description
-      "NewReno modification to TCP's fast recovery algorithm";
-    reference
-      "RFC 6582: The NewReno Modification to TCP's Fast Recovery
-       Algorithm";
-  }
-
-  identity ledbat {
-    base congestion-control-algorithm;
-    description
-      "Low Extra Delay Background Transport (LEDBAT) 
-       congestion control";
-   reference
-      "RFC 6817: Low Extra Delay Background Transport (LEDBAT)";
-  }
-
-  identity dctcp {
-    base congestion-control-algorithm;
-    description
-      "TCP Congestion Control for Data Centers (DCTCP)
-       congestion control";
-    reference
-      "RFC 8257: Data Center TCP (DCTCP): TCP Congestion
-       Control for Data Centers";
-  }
-
-  identity cubic {
-    base congestion-control-algorithm;
-    description
-      "CUBIC congestion control";
-    reference
-      "RFC 8312: CUBIC for Fast Long-Distance Networks";
-  }
-
-  grouping tcp-global {
-    description
-      "Important global TCP stack parameters.";
-    leaf mss-max {
-      type uint16;
-      description
-        "Sets the max segment size for TCP connections.";
-      reference
-        "RFC 1122: Requirements for Internet Hosts -- Communication
-         Layers";
-    }
-
-    leaf mtu-discovery-enable {
-      type boolean;
-      description
-        "Turns path mtu discovery for TCP connections on (true) or
-         off (false)";
-      reference
-        "RFC 4821: Packetization Layer Path MTU Discovery";
-    }
-
-    leaf sack-enable {
-      type boolean;
-      description
-        "Enable negotiation of Selective Acknowledgements (SACK)";
-      reference
-        "RFC 2018: TCP Selective Acknowledgment Options";
-    }
-
-    leaf timestamps-enable {
-      type boolean;
-      description
-        "Enable negotiation of timestamps";
-      reference
-        "RFC 7323: TCP Extensions for High Performance";
-    }
-
-    leaf window-scale-enable {
-      type boolean;
-      description
-        "Enable negotiation of receive window scaling";
-      reference
-        "RFC 7323: TCP Extensions for High Performance";
-    }
-
-    leaf ecn-enable {
-      type enumeration {
-        enum disable {
-          description
-	    "Disable the notification of ECN.";
-	}
-        enum passive {
-	  description
-            "Only advertise ECN support when asked for.";
-	}
-        enum active {
-	  description
-	  "Use ECN.";
-	}
-      }
-      description
-        "Enabling of Explicit Congestion Notification (ECN).";
-      reference
-        "RFC 3168: The Addition of Explicit Congestion
-         Notification (ECN) to IP";
-    }
-
-    leaf fin-timeout {
-      type uint16;
-      units "seconds";
-      description
-        "When a connection is closed actively, it must linger in
-         TIME-WAIT state for a time 2xMSL (Maximum Segment Lifetime).
-         This parameter sets the TIME-WAIT timeout duration in
-         seconds.";
-      reference
-         "RFC 793: Transmission Control Protocol";
-    }
-
-    leaf congestion-control-default {
-      type identityref {
-        base congestion-control-algorithm;
-      }
-      description
-        "This parameter selects the congestion control algorithm that
-         is used by default for new TCP connections. The default may
-         be overridden per connection by means outside the scope of
-         this model (e.g., via the Sockets API).";
-       reference
-         "RFC 2914: Congestion Control Principles";
     }
   }
 
@@ -357,19 +169,6 @@ module ietf-tcp {
 	container common {
 	  uses tcpcmn:tcp-common-grouping;
 
-          leaf congestion-control {
-            type identityref {
-              base congestion-control-algorithm;
-            }
-            config false;
-            description
-              "Type of the actually used TCP congestion control
-               algorithm. It may be different from the default
-               algorithm, for instance, if an application has
-               explicitly selected an algorithm.";
-            reference "RFC 2914: Congestion Control Principles";
-          }
-
           choice authentication {
             case ao {
               uses ao;
@@ -385,17 +184,10 @@ module ietf-tcp {
             description
               "Choice of how to secure the TCP connection.";
           }
-          leaf tcp-nodelay {
-            type boolean;
-            config false;
-            description
-              "Disabling of the 'Nagle algorithm'.";
-          }
           description
             "Common definitions of TCP configuration. This includes
              parameters such as how to secure the connection,
-             keepalives and idle time, that can be part of either
-             the client or server.";
+             that can be part of either the client or server.";
         }
         description
           "Connection related parameters.";
@@ -416,12 +208,6 @@ module ietf-tcp {
       uses tcpc:tcp-client-grouping;
       description
         "Definitions of TCP client configuration.";
-    }
-
-    container global {
-      uses tcp-global;
-      description
-        "Parameters affecting all TCP connections";
     }
 
     container statistics {

--- a/src/yang/not-an-example-tcp-configuration-a.1.2.xml
+++ b/src/yang/not-an-example-tcp-configuration-a.1.2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- This example sets all the global configuraiton parameters.
+ This example sets all the global configuration parameters.
 -->
 <config xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
   <tcp


### PR DESCRIPTION
This version of the draft strips it down to the bare min. of a draft. Gone are all congestion algorithms and most of the global configuration parameters except keepalive which is used by NETCONF.

Updated author affiliations.