### PR TITLE
Updated introduction text according to the narrow scope

### DIFF
--- a/draft/draft-scharf-tcpm-yang-tcp.xml
+++ b/draft/draft-scharf-tcpm-yang-tcp.xml
@@ -87,8 +87,8 @@
       compliant. This module defines a container for TCP connection, and
       includes definitions from <xref
       target="I-D.ietf-netconf-tcp-client-server">YANG Groupings for TCP
-      Clients and TCP Servers</xref>. The model focuses on fundamental and
-      standard TCP functions that are widely implemented. The model can be
+      Clients and TCP Servers</xref>. The model has a narrow scope and
+      focuses on fundamental TCP functions and basic statistics. The model can be
       augmented or updated to address more advanced or implementation-specific
       TCP features in the future.</t>
 
@@ -101,14 +101,35 @@
       means to configure the parameters listed in this document, which are
       outside the scope of this document.</t>
 
-      <t>This specification is orthogonal to <xref target="RFC4022">Management
+      <t>This specification does not deprecate the <xref target="RFC4022">Management
       Information Base (MIB) for the Transmission Control Protocol
-      (TCP)</xref>. The <xref target="RFC4898">TCP Extended Statistics
-      MIB</xref> is also available. It is possible to translate a MIB into a
+      (TCP)</xref>. The basic statistics defined in this document follow
+      the model of the TCP MIN. An <xref target="RFC4898">TCP Extended Statistics
+      MIB</xref> is also available, but this document does not cover such extended
+      statistics. It is possible also to translate a MIB into a
       YANG model, for instance using <xref target="RFC6643">Translation of
       Structure of Management Information Version 2 (SMIv2) MIB Modules to
       YANG Modules</xref>. However, this approach is not used in this
       document, as such a translated model would not be up-to-date.</t>
+
+      <t>There are other existing TCP-related YANG models, which are
+      othogonal to this specification. Examples are:</t>
+
+      <t><list style="symbols">
+          <t>TCP header attributes are modeled in other models, such as
+            <xref target="RFC8519">YANG Data Model for Network Access Control
+            Lists (ACLs) </xref> and <xref
+            target="I-D.ietf-dots-data-channel">Distributed Denial-of-Service
+            Open Thread Signaling (DOTS) Data Channel
+            Specification</xref>.</t>
+
+          <t>TCP-related configuration of a NAT (e.g., NAT44, NAT64,
+            Destination NAT, ...) is defined in <xref target="RFC8512">A YANG
+            Module for Network Address Translation (NAT) and Network Prefix
+            Translation (NPT) </xref> and <xref target="RFC8513">A YANG Data
+            Model for Dual-Stack Lite (DS-Lite) </xref>.</t>
+      </list></t>
+
     </section>
 
     <section title="Requirements Language">
@@ -163,7 +184,7 @@
 
             <t>Policies: Setting of TCP parameters can also be part of system
             policies, templates, or profiles. An example would be the
-            preferences defined in the TAPS interface <xref
+            preferences defined in <xref
             target="I-D.ietf-taps-interface">An Abstract Application Layer
             Interface to Transport Services</xref>.</t>
           </list></t>
@@ -174,57 +195,13 @@
         define a given configuration parameter globally, while another one
         uses per-interface settings, and both approaches work well for the
         corresponding use cases. Also, different systems may use different
-        default values.</t>
+        default values. In addition, TCP can be implemented in different ways
+        and design choices by the protocol engine often affect configuration
+        options.</t>
 
-        <t>In addition, TCP can be implemented in different ways and design
-        choices by the protocol engine often affect configuration options. In
-        a number of areas there are known differences between different TCP
-        stack architectures. This includes amongst others:</t>
-
-        <t><list style="symbols">
-            <t>Window size: TCP stacks can either store window state variables
-            (such as the congestion window) in segments or in bytes.</t>
-
-            <t>Buffer sizes: The memory management depends on the operating
-            system. As the size of buffers can vary over several orders of
-            magnitude, very different implementations exist. This typically
-            influences TCP flow control.</t>
-
-            <t>Timers: Timer implementation is another area in which TCP
-            stacks may differ.</t>
-          </list></t>
-
-        <t>Nonetheless, there are a number of basic system parameters that are
-        configurable on many TCP implementations, even if not all TCP
-        implementations may indeed have all these settings, and even if there
-        are differences regarding syntax and semantics. This document focuses
-        on modeling such basic parameters directly following from
-        standards.</t>
-
-        <t>In addition to configuration of the TCP protocol engine, a TCP
-        implementation typically also offers access to operational state and
-        statistics. This includes amongst others:</t>
-
-        <t><list style="symbols">
-            <t>Statistics: Counters for the number of active/passive opens,
-            sent and received segments, errors, and possibly other detailed
-            debugging information</t>
-
-            <t>TCP connection table: Access to status information for all TCP
-            connections</t>
-
-            <t>TCP listener table: Information about all TCP listening
-            endpoints</t>
-          </list></t>
-      </section>
-
-      <section title="Model Design">
-        <t>This document models fundamental system parameters that are
-        configurable on many TCP implementations, and for which the
-        configuration is reasonably similar. Similar to the <xref
-        target="RFC4022">TCP MIB</xref>, this document also specifies a TCP
-        connection table. This enables both global and connection-specific TCP
-        configuration.</t>
+        <t>Nonetheless, a number of TCP stack parameters require configuration
+        by YANG models. This document therefore defines a minimal YANG model
+        with fundamental parameters directly following from TCP standards.</t>
 
         <t>An important use case is the TCP configuration on network elements
         such as routers, which often use YANG data models. The model therefore
@@ -233,7 +210,29 @@
         target="RFC5925">TCP-AO</xref>. TCP-AO is increasingly supported on
         routers and it requires configuration.</t>
 
-        <t>The YANG model defined in this document includes definitions from
+        <t>Given an installed base, the model also allows enabling of the legacy
+        <xref target="RFC2385">TCP MD5</xref> signature option. As the TCP MD5 
+        signature option is obsoleted by TCP-AO, it is strongly RECOMMENDED to
+        use TCP-AO.</t>
+
+        <t>Similar to the <xref target="RFC4022">TCP MIB</xref>, this document
+        also specifies basic statistics and a TCP connection table.</t>
+   
+        <t><list style="symbols">
+            <t>Statistics: Counters for the number of active/passive opens,
+            sent and received segments, errors, and possibly other detailed
+            debugging information</t>
+
+            <t>TCP connection table: Access to status information for all TCP
+            connections</t>
+        </list></t>
+
+        <t>This allows implementations of <xref target="RFC4022">TCP MIB</xref>
+        to migrate to the YANG model defined in this memo.</t>
+      </section>
+
+      <section title="Model Design">
+         <t>The YANG model defined in this document includes definitions from
         the <xref target="I-D.ietf-netconf-tcp-client-server">YANG Groupings
         for TCP Clients and TCP Servers</xref>. Similar to that model, this
         specification defines YANG groupings. This allows reuse of these
@@ -242,24 +241,6 @@
         part of a stack of protocol-specific configuration models. An example
         could be the <xref target="I-D.ietf-idr-bgp-model">BGP YANG Model for
         Service Provider Networks </xref>.</t>
-
-        <t>There are also other existing TCP-related YANG models, which are
-        othogonal to this specification. Examples are:</t>
-
-        <t><list style="symbols">
-            <t>TCP header attributes are modeled in other models, such as
-            <xref target="RFC8519">YANG Data Model for Network Access Control
-            Lists (ACLs) </xref> and <xref
-            target="I-D.ietf-dots-data-channel">Distributed Denial-of-Service
-            Open Thread Signaling (DOTS) Data Channel
-            Specification</xref>.</t>
-
-            <t>TCP-related configuration of a NAT (e.g., NAT44, NAT64,
-            Destination NAT, ...) is defined in <xref target="RFC8512">A YANG
-            Module for Network Address Translation (NAT) and Network Prefix
-            Translation (NPT) </xref> and <xref target="RFC8513">A YANG Data
-            Model for Dual-Stack Lite (DS-Lite) </xref>.</t>
-          </list></t>
       </section>
 
       <section title="Tree Diagram">
@@ -363,7 +344,11 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD.yang)
 
       <?rfc include='reference.RFC.2119'?>
 
+      <?rfc include='reference.RFC.2385'?>
+
       <?rfc include='reference.RFC.3688'?>
+
+      <?rfc include='reference.RFC.5925'?>
 
       <?rfc include='reference.RFC.6020'?>
 
@@ -392,8 +377,6 @@ INSERT_TEXT_FROM_FILE(../src/yang/ietf-tcp@YYYY-MM-DD.yang)
       <?rfc include='reference.RFC.4022'?>
 
       <?rfc include='reference.RFC.4898'?>
-
-      <?rfc include='reference.RFC.5925'?>
 
       <?rfc include='reference.RFC.6643'?>
 


### PR DESCRIPTION
This is a purely editorial update to the first section to better reflect the narrow scope of a minimal model.

I suggest publish a -v06 before the cutoff deadline.