### PR TITLE
Fix AO configuration

### DIFF
--- a/src/validate-and-gen-trees.sh
+++ b/src/validate-and-gen-trees.sh
@@ -56,7 +56,7 @@ for i in yang/example-tcp-configuration-*.xml
 do
     name=$(echo $i | cut -f 1-4 -d '.')
     echo "Validating $name"
-    response=`yanglint -i -t config -p dependencies dependencies/ietf-key-chain@2017-06-15.yang yang/ietf-tcp\@$(date +%Y-%m-%d).yang $name`
+    response=`yanglint -ii -t config -p dependencies dependencies/ietf-key-chain@2017-06-15.yang yang/ietf-tcp\@$(date +%Y-%m-%d).yang $name`
     if [ $? -ne 0 ]; then
        printf "failed (error code: $?)\n"
        printf "$response\n\n"

--- a/src/yang/example-tcp-configuration-a.1.2.xml
+++ b/src/yang/example-tcp-configuration-a.1.2.xml
@@ -10,36 +10,52 @@ demonstrated by examples in draft-ietf-tcpm-ao-test-vectors.
     <name>ao-config</name>
     <description>"An example for TCP-AO configuration."</description>
     <key>
-      <key-id>61</key-id>
-      <crypto-algorithm>hmac-sha-1</crypto-algorithm>
+      <key-id>55</key-id>
+      <lifetime>
+        <send-lifetime>
+          <start-date-time>2017-01-01T00:00:00Z</start-date-time>
+          <end-date-time>2017-02-01T00:00:00Z</end-date-time>
+        </send-lifetime>
+        <accept-lifetime>
+          <start-date-time>2016-12-31T23:59:55Z</start-date-time>
+          <end-date-time>2017-02-01T00:00:05Z</end-date-time>
+        </accept-lifetime>
+      </lifetime>
+      <crypto-algorithm>hmac-sha-256</crypto-algorithm>
       <key-string>
 	<keystring>testvector</keystring>
       </key-string>
+      <authentication
+	  xmlns="urn:ietf:params:xml:ns:yang:ietf-tcp">
+	<keychain>ao-config</keychain>
+	<enable-ao>true</enable-ao>
+	<send-id>65</send-id>
+	<recv-id>87</recv-id>
+      </authentication>
     </key>
     <key>
-      <key-id>84</key-id>
-      <crypto-algorithm>hmac-sha-1</crypto-algorithm>
+      <key-id>56</key-id>
+      <lifetime>
+        <send-lifetime>
+          <start-date-time>2017-01-01T00:00:00Z</start-date-time>
+          <end-date-time>2017-02-01T00:00:00Z</end-date-time>
+        </send-lifetime>
+        <accept-lifetime>
+          <start-date-time>2016-12-31T23:59:55Z</start-date-time>
+          <end-date-time>2017-02-01T00:00:05Z</end-date-time>
+        </accept-lifetime>
+      </lifetime>
+      <crypto-algorithm>hmac-sha-256</crypto-algorithm>
       <key-string>
 	<keystring>testvector</keystring>
       </key-string>
+      <authentication
+	  xmlns="urn:ietf:params:xml:ns:yang:ietf-tcp">
+	<keychain>ao-config</keychain>
+	<enable-ao>true</enable-ao>
+	<send-id>65</send-id>
+	<recv-id>87</recv-id>
+      </authentication>
     </key>
   </key-chain>
 </key-chains>
-
-<tcp
-    xmlns="urn:ietf:params:xml:ns:yang:ietf-tcp">
-  <connections>
-    <connection>
-      <local-address>fd00::1</local-address>
-      <remote-address>fd00::2</remote-address>
-      <local-port>1025</local-port>
-      <remote-port>179</remote-port>
-      <authentication>
-	<keychain>ao-config</keychain>
-	<enable-ao>true</enable-ao>
-        <send-id>61</send-id>
-        <recv-id>84</recv-id>
-      </authentication>
-    </connection>
-  </connections>
-</tcp>

--- a/src/yang/ietf-tcp.yang
+++ b/src/yang/ietf-tcp.yang
@@ -220,38 +220,6 @@ module ietf-tcp {
 
         uses tcpcmn:tcp-common-grouping;
 
-        container authentication {
-          leaf keychain {
-            type key-chain:key-chain-ref;
-            description
-              "Reference to the key chain that will be used by
-               this model. Applicable for TCP-AO and TCP-MD5
-               only";
-            reference
-              "RFC 8177: YANG Key Chain.";
-          }
-
-          choice authentication {
-            case ao {
-              uses ao;
-              description
-                "Use TCP-AO to secure the connection.";
-            }
-
-            case md5 {
-              uses md5;
-              description
-                "Use TCP-MD5 to secure the connection.";
-            }
-            description
-              "Choice of TCP authentication.";
-          }
-          description
-            "Authentication definitions for TCP configuration.
-             This includes parameters such as how to secure the
-             connection, that can be part of either the client
-             or server.";
-        }
         description
           "List of TCP connections with their parameters. The list
            is modeled as writeable, but implementations may not
@@ -398,6 +366,45 @@ module ietf-tcp {
       }
       description
         "Statistics across all connections.";
+    }
+  }
+
+  augment "/key-chain:key-chains/key-chain:key-chain/key-chain:key" {
+    description
+      "Augmentation of the key-chain model to add TCP-AO and TCP-MD5
+       authentication.";
+
+    container authentication {
+      leaf keychain {
+        type key-chain:key-chain-ref;
+        description
+          "Reference to the key chain that will be used by
+           this model. Applicable for TCP-AO and TCP-MD5
+           only";
+        reference
+          "RFC 8177: YANG Key Chain.";
+      }
+
+      choice authentication {
+        case ao {
+          uses ao;
+          description
+            "Use TCP-AO to secure the connection.";
+        }
+
+        case md5 {
+          uses md5;
+          description
+            "Use TCP-MD5 to secure the connection.";
+        }
+        description
+          "Choice of TCP authentication.";
+      }
+      description
+        "Authentication definitions for TCP configuration.
+         This includes parameters such as how to secure the
+         connection, that can be part of either the client
+         or server.";
     }
   }
 }


### PR DESCRIPTION
This is yet another attempt to fix TCP-AO configuration. The biggest change with this is that rather than TCP module maintaining parameters related to AO configuration, e.g. send-id and recv-id, it defers that part of the configuration to the key-chain model by augmenting the key-chain model. Although the title says AO, but the MD5 configuration is also moved.

The corresponding examples have also been updated.